### PR TITLE
fix: 修复docker-compose.yml中对于resourse的只读权限。

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     volumes:
       - ./storage:/NarratoAI/storage
       - ./config.toml:/NarratoAI/config.toml
-      - ./resource:/NarratoAI/resource:ro
+      - ./resource:/NarratoAI/resource:rw
 
     environment:
       - PYTHONUNBUFFERED=1


### PR DESCRIPTION
## PR 类型
请选择一个适当的标签（必选其一）：

- [ ] 破坏性变更 (breaking)
- [ ] 安全修复 (security)
- [ ] 新功能 (feature)
- [x] Bug修复 (bug)
- [ ] 代码重构 (refactor)
- [ ] 依赖升级 (upgrade)
- [ ] 文档更新 (docs)
- [ ] 翻译相关 (lang-all)
- [ ] 内部改进 (internal)

## 描述
<!-- 请提供对此次更改的清晰描述。为什么需要这个更改？它解决了什么问题？ -->
<img width="1483" height="765" alt="Screenshot 2025-09-29 at 09 51 22" src="https://github.com/user-attachments/assets/df3aedc2-b422-4ede-90bc-921381dc20e7" />
挂载在镜像的./resource:/NarratoAI/resource为只读，用户上传视频资源会失败，需要改为读写。


## 相关 Issue
<!-- 请链接相关的 issue（如果有）。例如：Fixes #123 -->

## 更改内容
<!-- 详细描述具体更改了什么 -->

- 修改docker-compose.yml

## 测试
<!-- 描述如何测试你的更改 -->

- [ ] 单元测试
- [ ] 集成测试
- [x] 手动测试

## 截图（如果适用）
<!-- 如果是UI相关的更改，请提供截图 -->

## 检查清单

- [x] 我的代码遵循项目的代码风格
- [ ] 我已经添加了必要的测试
- [ ] 我已经更新了相关文档
- [x] 我的更改不会引入新的警告
- [x] PR 标题清晰描述了更改内容

## 补充说明
<!-- 任何其他相关信息 -->