### PR TITLE
Fix subtitle preview orientation state

### DIFF
--- a/webui/components/subtitle_settings.py
+++ b/webui/components/subtitle_settings.py
@@ -47,6 +47,13 @@ SUBTITLE_PREVIEW_FALLBACK_SIZES = {
     "landscape": (1920, 1080),
 }
 
+SUBTITLE_PREVIEW_ORIENTATIONS = ("portrait", "landscape")
+
+SUBTITLE_PREVIEW_ORIENTATION_LABELS = {
+    "portrait": "Portrait Safe Area",
+    "landscape": "Landscape Safe Area",
+}
+
 
 def render_subtitle_panel(tr):
     """渲染字幕设置面板"""
@@ -128,6 +135,25 @@ def _get_current_preview_video_path():
                 return path
 
     return ""
+
+
+def _normalize_subtitle_preview_orientation(value, tr=None):
+    if value in SUBTITLE_PREVIEW_ORIENTATIONS:
+        return value
+
+    labels = {
+        label: orientation
+        for orientation, label in SUBTITLE_PREVIEW_ORIENTATION_LABELS.items()
+    }
+    if tr:
+        labels.update(
+            {
+                tr(label): orientation
+                for orientation, label in SUBTITLE_PREVIEW_ORIENTATION_LABELS.items()
+            }
+        )
+
+    return labels.get(str(value), "portrait")
 
 
 def _save_subtitle_mask_preview_video(uploaded_file):
@@ -753,11 +779,17 @@ def _render_subtitle_preview_image(tr):
     stroke_color = st.session_state.get("stroke_color", config.ui.get("stroke_color", "#000000"))
     stroke_width = float(st.session_state.get("stroke_width", config.ui.get("stroke_width", 1.5)) or 0)
 
+    orientation_default = _normalize_subtitle_preview_orientation(
+        st.session_state.get("subtitle_preview_orientation", "portrait"),
+        tr,
+    )
+    st.session_state["subtitle_preview_orientation"] = orientation_default
+
     orientation = st.pills(
         tr("Subtitle Preview Orientation"),
-        options=["portrait", "landscape"],
-        default=st.session_state.get("subtitle_preview_orientation", "portrait"),
-        format_func=lambda value: tr("Portrait Safe Area") if value == "portrait" else tr("Landscape Safe Area"),
+        options=SUBTITLE_PREVIEW_ORIENTATIONS,
+        default=orientation_default,
+        format_func=lambda value: tr(SUBTITLE_PREVIEW_ORIENTATION_LABELS[value]),
         key="subtitle_preview_orientation",
         width="stretch",
     ) or "portrait"

--- a/webui/components/test_subtitle_settings_unittest.py
+++ b/webui/components/test_subtitle_settings_unittest.py
@@ -1,0 +1,21 @@
+import unittest
+
+from webui.components.subtitle_settings import _normalize_subtitle_preview_orientation
+
+
+class SubtitleSettingsPreviewOrientationTests(unittest.TestCase):
+    def test_normalize_subtitle_preview_orientation_accepts_canonical_values(self):
+        self.assertEqual("portrait", _normalize_subtitle_preview_orientation("portrait"))
+        self.assertEqual("landscape", _normalize_subtitle_preview_orientation("landscape"))
+
+    def test_normalize_subtitle_preview_orientation_migrates_legacy_labels(self):
+        self.assertEqual("portrait", _normalize_subtitle_preview_orientation("Portrait Safe Area"))
+        self.assertEqual("landscape", _normalize_subtitle_preview_orientation("Landscape Safe Area"))
+
+    def test_normalize_subtitle_preview_orientation_falls_back_to_portrait(self):
+        self.assertEqual("portrait", _normalize_subtitle_preview_orientation(None))
+        self.assertEqual("portrait", _normalize_subtitle_preview_orientation("unexpected"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Normalize subtitle preview orientation session state before rendering `st.pills`.
- Migrate legacy display labels like `Portrait Safe Area` back to canonical values.
- Add regression tests for canonical, legacy, and invalid preview orientation values.

## Root Cause
Streamlit validates `st.pills` defaults against the raw option values. A stale display label stored in session state could be passed as the default even though the actual options are `portrait` and `landscape`, causing `StreamlitAPIException`.

## Validation
- `uv run pytest webui/components/test_subtitle_settings_unittest.py -q`
- `uv run pytest tests/test_generate_script_docu_unittest.py -q`