### PR TITLE
Normalize audio source pill state

### DIFF
--- a/webui/components/audio_settings.py
+++ b/webui/components/audio_settings.py
@@ -47,6 +47,18 @@ LOCAL_TTS_ENGINES = {
 }
 
 
+def _normalize_source_pills_value(value, option_labels, default_value, tr=lambda key: key):
+    if value in option_labels:
+        return value
+
+    label_values = {}
+    for option_value, label_key in option_labels.items():
+        label_values[label_key] = option_value
+        label_values[tr(label_key)] = option_value
+
+    return label_values.get(str(value), default_value)
+
+
 def get_soulvoice_voices():
     """获取 SoulVoice 语音列表"""
     # 检查是否配置了 SoulVoice API key
@@ -380,34 +392,36 @@ def render_reference_audio_preview_button(reference_audio, key, tr, preview_stat
 def render_indextts_reference_audio_selector(tr, tts_config, key_prefix):
     """渲染 IndexTTS 系列共用的参考音频选择器。"""
     saved_reference_audio = tts_config.get("reference_audio", "")
-    reference_audio_source_options = {
-        tr("Select from Resource Directory"): "resource",
-        tr("Upload Reference Audio"): "upload",
+    reference_audio_source_labels = {
+        "resource": "Select from Resource Directory",
+        "upload": "Upload Reference Audio",
     }
-    reference_audio_source_labels = list(reference_audio_source_options.keys())
     saved_reference_audio_source = tts_config.get("reference_audio_source", "resource")
-    if saved_reference_audio_source not in reference_audio_source_options.values():
+    if saved_reference_audio_source not in reference_audio_source_labels:
         saved_reference_audio_source = "resource"
-    default_reference_audio_source_label = next(
-        label
-        for label, source_value in reference_audio_source_options.items()
-        if source_value == saved_reference_audio_source
+    reference_audio_source_key = f"{key_prefix}_reference_audio_source_selection"
+    default_reference_audio_source = _normalize_source_pills_value(
+        st.session_state.get(reference_audio_source_key, saved_reference_audio_source),
+        reference_audio_source_labels,
+        saved_reference_audio_source,
+        tr,
     )
+    st.session_state[reference_audio_source_key] = default_reference_audio_source
 
     st.markdown(f"**{tr('Reference Audio Path')}**")
-    reference_audio_source_label = st.pills(
+    reference_audio_source = st.pills(
         tr("Reference Audio Source"),
-        options=reference_audio_source_labels,
+        options=list(reference_audio_source_labels.keys()),
         selection_mode="single",
-        default=default_reference_audio_source_label,
-        key=f"{key_prefix}_reference_audio_source_selection",
+        default=default_reference_audio_source,
+        key=reference_audio_source_key,
+        format_func=lambda source: tr(reference_audio_source_labels[source]),
         help=tr("Reference Audio Source Help"),
         label_visibility="collapsed",
         width="stretch",
     )
-    if not reference_audio_source_label:
-        reference_audio_source_label = default_reference_audio_source_label
-    reference_audio_source = reference_audio_source_options[reference_audio_source_label]
+    if not reference_audio_source:
+        reference_audio_source = default_reference_audio_source
 
     reference_audio = saved_reference_audio
     preview_state_key = f"{key_prefix}_reference_audio_preview_path"
@@ -1931,35 +1945,36 @@ def render_bgm_settings(tr):
     if st.session_state.get('bgm_type') == "":
         saved_bgm_source = "none"
 
-    bgm_source_options = {
-        tr("Select from Resource Directory"): "resource",
-        tr("Upload Background Music"): "upload",
-        tr("No Background Music"): "none",
+    bgm_source_labels = {
+        "resource": "Select from Resource Directory",
+        "upload": "Upload Background Music",
+        "none": "No Background Music",
     }
-    if saved_bgm_source not in bgm_source_options.values():
+    if saved_bgm_source not in bgm_source_labels:
         saved_bgm_source = "resource"
 
-    default_bgm_source_label = next(
-        label
-        for label, source_value in bgm_source_options.items()
-        if source_value == saved_bgm_source
+    default_bgm_source = _normalize_source_pills_value(
+        st.session_state.get("bgm_source_selection", saved_bgm_source),
+        bgm_source_labels,
+        saved_bgm_source,
+        tr,
     )
+    st.session_state["bgm_source_selection"] = default_bgm_source
 
     st.markdown(f"**{tr('Background Music')}**")
-    bgm_source_label = st.pills(
+    bgm_source = st.pills(
         tr("Background Music Source"),
-        options=list(bgm_source_options.keys()),
+        options=list(bgm_source_labels.keys()),
         selection_mode="single",
-        default=default_bgm_source_label,
+        default=default_bgm_source,
         key="bgm_source_selection",
+        format_func=lambda source: tr(bgm_source_labels[source]),
         help=tr("Background Music Source Help"),
         label_visibility="collapsed",
         width="stretch",
     )
-    if not bgm_source_label:
-        bgm_source_label = default_bgm_source_label
-
-    bgm_source = bgm_source_options[bgm_source_label]
+    if not bgm_source:
+        bgm_source = default_bgm_source
     bgm_file = ""
     bgm_name = ""
 

--- a/webui/components/test_audio_settings_unittest.py
+++ b/webui/components/test_audio_settings_unittest.py
@@ -1,0 +1,49 @@
+import unittest
+
+from webui.components.audio_settings import _normalize_source_pills_value
+
+
+def zh_tr(key):
+    return {
+        "Select from Resource Directory": "从资源目录选择",
+        "Upload Reference Audio": "上传参考音频",
+        "Upload Background Music": "上传背景音乐",
+    }.get(key, key)
+
+
+class AudioSettingsSourcePillsTests(unittest.TestCase):
+    def test_normalize_source_pills_value_keeps_canonical_value(self):
+        options = {
+            "resource": "Select from Resource Directory",
+            "upload": "Upload Reference Audio",
+        }
+
+        self.assertEqual("upload", _normalize_source_pills_value("upload", options, "resource", zh_tr))
+
+    def test_normalize_source_pills_value_migrates_current_translated_label(self):
+        options = {
+            "resource": "Select from Resource Directory",
+            "upload": "Upload Reference Audio",
+        }
+
+        self.assertEqual("resource", _normalize_source_pills_value("从资源目录选择", options, "upload", zh_tr))
+
+    def test_normalize_source_pills_value_migrates_untranslated_label_key(self):
+        options = {
+            "resource": "Select from Resource Directory",
+            "upload": "Upload Background Music",
+        }
+
+        self.assertEqual("upload", _normalize_source_pills_value("Upload Background Music", options, "resource", zh_tr))
+
+    def test_normalize_source_pills_value_falls_back_to_default(self):
+        options = {
+            "resource": "Select from Resource Directory",
+            "upload": "Upload Reference Audio",
+        }
+
+        self.assertEqual("resource", _normalize_source_pills_value("invalid", options, "resource", zh_tr))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Store audio source pills as stable values (`resource`, `upload`, `none`) instead of translated display labels.
- Normalize legacy translated or untranslated labels before rendering Streamlit pills.
- Add regression tests for canonical values, translated labels, label keys, and invalid fallback behavior.

## Why
Translated labels can survive in Streamlit session state. If the option list changes language or switches to stable option values, stale labels may no longer be valid widget values. Keeping the stored state canonical makes the controls resilient across reruns and language changes.

## Validation
- `uv run pytest webui/components/test_audio_settings_unittest.py -q`
- `uv run pytest tests/test_generate_script_docu_unittest.py -q`