### PR TITLE
Add Atlas Cloud text provider

### DIFF
--- a/app/config/defaults.py
+++ b/app/config/defaults.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 DEFAULT_OPENAI_COMPATIBLE_BASE_URL = "https://api.siliconflow.cn/v1"
 DEFAULT_OPENAI_COMPATIBLE_PROVIDER = "openai"
+DEFAULT_ATLASCLOUD_BASE_URL = "https://api.atlascloud.ai/v1"
+DEFAULT_ATLASCLOUD_TEXT_MODEL_NAME = "qwen/qwen3.5-flash"
 
 DEFAULT_VISION_LLM_PROVIDER = DEFAULT_OPENAI_COMPATIBLE_PROVIDER
 DEFAULT_VISION_OPENAI_MODEL_NAME = "Qwen/Qwen3.5-122B-A10B"
@@ -35,6 +37,9 @@ DEFAULT_LLM_APP_CONFIG = {
     "text_openai_model_name": DEFAULT_TEXT_OPENAI_MODEL_NAME,
     "text_openai_api_key": "",
     "text_openai_base_url": DEFAULT_OPENAI_COMPATIBLE_BASE_URL,
+    "text_atlascloud_model_name": DEFAULT_ATLASCLOUD_TEXT_MODEL_NAME,
+    "text_atlascloud_api_key": "",
+    "text_atlascloud_base_url": DEFAULT_ATLASCLOUD_BASE_URL,
     "tavily_api_key": "",
     "tavily_search_depth": "basic",
     "tavily_max_results": 5,

--- a/app/config/test_config_bootstrap_unittest.py
+++ b/app/config/test_config_bootstrap_unittest.py
@@ -10,6 +10,8 @@ except ModuleNotFoundError:  # Python < 3.11
 
 from app.config import config as cfg
 from app.config.defaults import (
+    DEFAULT_ATLASCLOUD_BASE_URL,
+    DEFAULT_ATLASCLOUD_TEXT_MODEL_NAME,
     get_openai_compatible_ui_values,
     normalize_openai_compatible_model_name,
 )
@@ -83,6 +85,9 @@ hide_config = true
         self.assertEqual("openai", config_data["app"]["text_llm_provider"])
         self.assertEqual("Pro/zai-org/GLM-5", config_data["app"]["text_openai_model_name"])
         self.assertEqual("https://api.siliconflow.cn/v1", config_data["app"]["text_openai_base_url"])
+        self.assertEqual(DEFAULT_ATLASCLOUD_TEXT_MODEL_NAME, config_data["app"]["text_atlascloud_model_name"])
+        self.assertEqual(DEFAULT_ATLASCLOUD_BASE_URL, config_data["app"]["text_atlascloud_base_url"])
+        self.assertEqual("", config_data["app"]["text_atlascloud_api_key"])
         self.assertEqual(1.0, config_data["app"]["text_openai_temperature"])
         self.assertEqual(0.95, config_data["app"]["text_openai_top_p"])
         self.assertEqual("Qwen/Qwen3.5-122B-A10B", saved_config["app"]["vision_openai_model_name"])

--- a/app/services/llm/openai_compatible_provider.py
+++ b/app/services/llm/openai_compatible_provider.py
@@ -24,7 +24,6 @@ from openai import (
 from app.config import config
 from app.config.defaults import DEFAULT_LLM_GENERATION_CONFIG, normalize_openai_compatible_model_name
 from app.utils.openai_base_url_security import (
-    is_trusted_openai_compatible_base_url,
     openai_compatible_base_url_warning,
     validate_openai_compatible_base_url as _validate_openai_compatible_base_url_value,
 )
@@ -444,3 +443,11 @@ class OpenAICompatibleTextProvider(_OpenAICompatibleBase, TextModelProvider):
 
     async def _make_api_call(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         return payload
+
+
+class AtlasCloudTextProvider(OpenAICompatibleTextProvider):
+    """Atlas Cloud text provider using the existing OpenAI-compatible chat path."""
+
+    @property
+    def provider_name(self) -> str:
+        return "atlascloud"

--- a/app/services/llm/providers/__init__.py
+++ b/app/services/llm/providers/__init__.py
@@ -20,6 +20,7 @@ def register_all_providers():
 
     # 只导入 OpenAI 兼容 provider
     from ..openai_compatible_provider import (
+        AtlasCloudTextProvider,
         OpenAICompatibleVisionProvider,
         OpenAICompatibleTextProvider,
     )
@@ -29,6 +30,7 @@ def register_all_providers():
     # ===== 注册 OpenAI 兼容统一接口 =====
     LLMServiceManager.register_vision_provider('openai', OpenAICompatibleVisionProvider)
     LLMServiceManager.register_text_provider('openai', OpenAICompatibleTextProvider)
+    LLMServiceManager.register_text_provider('atlascloud', AtlasCloudTextProvider)
 
     logger.info("✅ OpenAI 兼容提供商注册完成")
 

--- a/app/services/llm/test_openai_compat_unittest.py
+++ b/app/services/llm/test_openai_compat_unittest.py
@@ -55,8 +55,8 @@ class OpenAICompatManagerTests(unittest.TestCase):
     def test_register_all_providers_registers_expected_providers(self):
         register_all_providers()
 
-        # 文本仅 OpenAI 兼容；视觉额外提供可选的 TwelveLabs Pegasus。
-        self.assertEqual({"openai"}, set(LLMServiceManager.list_text_providers()))
+        # 文本提供 OpenAI-compatible aliases；视觉额外提供可选的 TwelveLabs Pegasus。
+        self.assertEqual({"openai", "atlascloud"}, set(LLMServiceManager.list_text_providers()))
         self.assertEqual({"openai", "twelvelabs"}, set(LLMServiceManager.list_vision_providers()))
 
     def test_get_text_provider_uses_openai_keys(self):
@@ -73,6 +73,21 @@ class OpenAICompatManagerTests(unittest.TestCase):
         self.assertEqual("new-key", provider.api_key)
         self.assertEqual("new-model", provider.model_name)
         self.assertEqual("https://new.example/v1", provider.base_url)
+
+    def test_get_text_provider_supports_atlascloud_alias(self):
+        register_all_providers()
+
+        config.app["text_llm_provider"] = "atlascloud"
+        config.app["text_atlascloud_api_key"] = "atlas-key"
+        config.app["text_atlascloud_model_name"] = "qwen/qwen3.5-flash"
+        config.app["text_atlascloud_base_url"] = "https://api.atlascloud.ai/v1"
+
+        provider = LLMServiceManager.get_text_provider()
+
+        self.assertEqual("atlascloud", provider.provider_name)
+        self.assertEqual("atlas-key", provider.api_key)
+        self.assertEqual("qwen/qwen3.5-flash", provider.model_name)
+        self.assertEqual("https://api.atlascloud.ai/v1", provider.base_url)
 
 
 class OpenAICompatVisionConcurrencyTests(unittest.IsolatedAsyncioTestCase):
@@ -191,6 +206,7 @@ class OpenAICompatBaseURLValidationTests(unittest.TestCase):
             "https://api.siliconflow.cn/v1",
             "https://openrouter.ai/api/v1",
             "https://dashscope.aliyuncs.com/compatible-mode/v1",
+            "https://api.atlascloud.ai/v1",
             "https://example.openai.azure.com/openai/deployments/demo",
             "http://localhost:11434/v1",
             "http://127.0.0.1:11434/v1",

--- a/app/utils/openai_base_url_security.py
+++ b/app/utils/openai_base_url_security.py
@@ -15,6 +15,7 @@ TRUSTED_OPENAI_COMPATIBLE_BASE_HOSTS = {
     "generativelanguage.googleapis.com",
     "open.bigmodel.cn",
     "api.z.ai",
+    "api.atlascloud.ai",
     "ark.cn-beijing.volces.com",
     "ark.cn-shanghai.volces.com",
 }

--- a/config.example.toml
+++ b/config.example.toml
@@ -61,6 +61,12 @@
     text_openai_max_tokens = 65536
     text_openai_thinking_level = "auto"  # auto/off/low/medium/high
 
+    # Atlas Cloud 文本模型（OpenAI-compatible）
+    # 使用方式：将 text_llm_provider 改为 "atlascloud"，并填入 text_atlascloud_api_key
+    text_atlascloud_model_name = "qwen/qwen3.5-flash"
+    text_atlascloud_api_key = ""
+    text_atlascloud_base_url = "https://api.atlascloud.ai/v1"
+
     # ===== Tavily 联网搜索配置 =====
     # 用于短剧剧情理解前，按短剧名称检索公开剧情/人物/分集信息
     tavily_api_key = ""  # 获取地址：https://app.tavily.com


### PR DESCRIPTION
## Summary
- add an `atlascloud` text provider using NarratoAI's existing OpenAI-compatible chat path
- add Atlas Cloud defaults for `ATLASCLOUD_API_KEY`, `https://api.atlascloud.ai/v1`, and `qwen/qwen3.5-flash`
- trust the Atlas Cloud OpenAI-compatible base URL and cover provider registration/defaults with focused tests

## Validation
- `git diff --check`
- `python3 -m py_compile app/config/defaults.py app/services/llm/openai_compatible_provider.py app/services/llm/providers/__init__.py app/utils/openai_base_url_security.py app/services/llm/test_openai_compat_unittest.py app/config/test_config_bootstrap_unittest.py`
- `UV_PROJECT_ENVIRONMENT=.venv312 /Users/zby/.local/bin/uv run --python 3.12 python -m unittest app.services.llm.test_openai_compat_unittest app.config.test_config_bootstrap_unittest` (22 tests)
- `UV_PROJECT_ENVIRONMENT=.venv312 /Users/zby/.local/bin/uv run --python 3.12 --with ruff ruff check app/config/defaults.py app/config/test_config_bootstrap_unittest.py app/services/llm/openai_compatible_provider.py app/services/llm/providers/__init__.py app/services/llm/test_openai_compat_unittest.py app/utils/openai_base_url_security.py`
- Atlas Cloud live model catalog check confirmed `qwen/qwen3.5-flash`

No README changes; `config.example.toml` only adds a technical provider configuration example.
