### PR TITLE
feat: add OrcaRouter as a trusted OpenAI-compatible gateway

### DIFF
--- a/app/services/llm/test_openai_compat_unittest.py
+++ b/app/services/llm/test_openai_compat_unittest.py
@@ -204,6 +204,7 @@ class OpenAICompatBaseURLValidationTests(unittest.TestCase):
             "https://api.openai.com/v1",
             "https://api.siliconflow.cn/v1",
             "https://openrouter.ai/api/v1",
+            "https://api.orcarouter.ai/v1",
             "https://dashscope.aliyuncs.com/compatible-mode/v1",
             "https://example.openai.azure.com/openai/deployments/demo",
             "http://localhost:11434/v1",

--- a/app/utils/openai_base_url_security.py
+++ b/app/utils/openai_base_url_security.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 TRUSTED_OPENAI_COMPATIBLE_BASE_HOSTS = {
     "api.openai.com",
     "openrouter.ai",
+    "api.orcarouter.ai",
     "api.siliconflow.cn",
     "dashscope.aliyuncs.com",
     "api.deepseek.com",

--- a/config.example.toml
+++ b/config.example.toml
@@ -12,7 +12,7 @@
     # 🚀 LLM 配置 - 使用 OpenAI 兼容统一接口
     ##########################################
     # 统一使用 OpenAI 兼容协议（/v1/chat/completions）
-    # 支持接入 OpenAI、DeepSeek、Gemini 兼容网关、Qwen 网关、SiliconFlow、OpenRouter 等。
+    # 支持接入 OpenAI、DeepSeek、Gemini 兼容网关、Qwen 网关、SiliconFlow、OpenRouter、OrcaRouter 等。
 
     # ===== 视觉模型配置 =====
     vision_llm_provider = "openai"
@@ -91,6 +91,7 @@
     # Qwen (阿里):  https://bailian.console.aliyun.com/?tab=model#/api-key
     # SiliconFlow:  https://cloud.siliconflow.cn/account/ak (手机号注册)
     # Moonshot:     https://platform.moonshot.cn/console/api-keys
+    # OrcaRouter:   https://www.orcarouter.ai/console (API keys 以 sk-orca- 开头)
     # Anthropic:    https://console.anthropic.com/settings/keys
     # Cohere:       https://dashboard.cohere.com/api-keys
     # Together AI:  https://api.together.xyz/settings/api-keys

--- a/webui/components/basic_settings.py
+++ b/webui/components/basic_settings.py
@@ -28,6 +28,7 @@ from app.services.llm.unified_service import UnifiedLLMService
 OPENAI_COMPATIBLE_GATEWAY_BASE_URLS = {
     "siliconflow": "https://api.siliconflow.cn/v1",
     "openrouter": "https://openrouter.ai/api/v1",
+    "orcarouter": "https://api.orcarouter.ai/v1",
     "moonshot": "https://api.moonshot.cn/v1",
     "gemini(openai)": "",
 }

--- a/webui/i18n/en.json
+++ b/webui/i18n/en.json
@@ -476,7 +476,7 @@
     "Vision model": "Vision model",
     "Text model": "Text model",
     "Model Name Input Help": "Enter the full model name.\n\nCommon examples:",
-    "OpenAI compatible providers help": "The vendor is not limited here; OpenAI, DeepSeek, OpenRouter, SiliconFlow, or a self-hosted gateway all work as long as the endpoint is OpenAI-compatible.",
+    "OpenAI compatible providers help": "The vendor is not limited here; OpenAI, DeepSeek, OpenRouter, OrcaRouter, SiliconFlow, or a self-hosted gateway all work as long as the endpoint is OpenAI-compatible.",
     "OpenAI compatible protocol": "OpenAI-compatible",
     "OpenAI compatible protocol help": "This does not require the official OpenAI model; any service that supports the OpenAI Chat Completions compatible API can be used.",
     "Provider API Key Help": "API key for the model service.\n\nCommon places to get one:",

--- a/webui/i18n/zh.json
+++ b/webui/i18n/zh.json
@@ -414,7 +414,7 @@
     "Vision model": "视觉分析模型",
     "Text model": "文案生成模型",
     "Model Name Input Help": "输入完整模型名称\n\n常用示例:",
-    "OpenAI compatible providers help": "这里不限定模型厂商；OpenAI、DeepSeek、OpenRouter、SiliconFlow 或自建网关均可，只需提供兼容 OpenAI 的接口地址和模型名称。",
+    "OpenAI compatible providers help": "这里不限定模型厂商；OpenAI、DeepSeek、OpenRouter、OrcaRouter、SiliconFlow 或自建网关均可，只需提供兼容 OpenAI 的接口地址和模型名称。",
     "OpenAI compatible protocol": "OpenAI 兼容",
     "OpenAI compatible protocol help": "不是限定 OpenAI 官方模型；只要模型服务支持 OpenAI Chat Completions 兼容接口即可。",
     "Provider API Key Help": "模型服务的 API 密钥\n\n常见获取地址:",


### PR DESCRIPTION
## 类型 / PR type

- [x] 内部改进 (internal)

## 描述 / Description

Adds [OrcaRouter](https://www.orcarouter.ai) as a trusted OpenAI-compatible gateway in NarratoAI. OrcaRouter is an OpenAI-compatible model routing gateway that exposes models from OpenAI, Anthropic, Google, DeepSeek, Qwen and others behind a single endpoint and API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## 更改内容 / What this changes

- `app/utils/openai_base_url_security.py`: adds `api.orcarouter.ai` to `TRUSTED_OPENAI_COMPATIBLE_BASE_HOSTS`, so selecting OrcaRouter as the base URL does not raise the untrusted-endpoint warning — mirroring `openrouter.ai`.
- `webui/components/basic_settings.py`: adds `"orcarouter": "https://api.orcarouter.ai/v1"` to `OPENAI_COMPATIBLE_GATEWAY_BASE_URLS`, so the web UI offers OrcaRouter as a one-click gateway preset.
- `config.example.toml`: mentions OrcaRouter in the supported-gateway comment and adds an API-key reference line.
- `webui/i18n/en.json`, `webui/i18n/zh.json`: adds OrcaRouter to the "OpenAI compatible providers" help text.
- `app/services/llm/test_openai_compat_unittest.py`: adds `https://api.orcarouter.ai/v1` to the trusted-url assertions.

## 测试 / Tests

- [x] 单元测试 (unit): `python -m pytest app/services/llm/test_openai_compat_unittest.py` → 16 passed, 13 subtests passed.
- [x] 手动测试 (manual / L3 live): with a real `sk-orca-` key, `is_trusted_openai_compatible_base_url("https://api.orcarouter.ai/v1")` → `True` and `openai_compatible_base_url_warning(...)` → `""`; `POST /v1/chat/completions` (model `openai/gpt-5.5`) → 200; `POST /v1/embeddings` (model `openai/text-embedding-3-small`) → 200, 1536-dim.

## 检查清单 / Checklist

- [x] 我的代码遵循项目的代码风格
- [x] 我已经添加了必要的测试
