### PR TITLE
docs: 修复失效的 Star History 图表链接

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -128,4 +128,4 @@ Click to view [`LICENSE`](LICENSE) file
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=linyqh/NarratoAI&type=Date)](https://star-history.com/#linyqh/NarratoAI&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=linyqh/NarratoAI&type=Date)](https://star-history.dera.page/#linyqh/NarratoAI&Date)

--- a/README.md
+++ b/README.md
@@ -208,4 +208,4 @@ uv run streamlit run webui.py --server.maxUploadSize=2048
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=linyqh/NarratoAI&type=Date)](https://star-history.com/#linyqh/NarratoAI&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=linyqh/NarratoAI&type=Date)](https://star-history.dera.page/#linyqh/NarratoAI&Date)


### PR DESCRIPTION
README 中的 Star History 图表目前已经无法正常显示，原因是最初使用的图表服务受 GitHub stargazer API 限制影响。

本 PR 将图表链接切换到可正常工作的替代服务（star-history.dera.page），使图表重新可用，无需申请任何 API token。