### PR TITLE
docs: 移除英文 README 中失效的日文链接

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -3,7 +3,7 @@
 <h3 align="center">An all-in-one AI-powered tool for film commentary and automated video editing.🎬🎞️ </h3>
 
 
-<h3>📖 English | <a href="README.md">简体中文</a> | <a href="README-ja.md">日本語</a> </h3>
+<h3>📖 English | <a href="README.md">简体中文</a> </h3>
 <div align="center">
 
 [//]: # (  <a href="https://trendshift.io/repositories/8731" target="_blank"><img src="https://trendshift.io/api/badge/repositories/8731" alt="harry0703%2FNarratoAI | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>)


### PR DESCRIPTION
## PR 类型

- [x] 文档更新 (docs)

## 描述

英文 README 的语言导航指向仓库中不存在的 `README-ja.md`，点击后会返回 404。本次移除该失效入口，保留当前有效的英文和简体中文导航。

## 相关 Issue

无。

## 更改内容

- 移除英文 README 中指向缺失 `README-ja.md` 的日文链接。
- 保留现有英文和简体中文入口。

## 测试

- [x] 确认当前仓库不存在 `README-ja.md`
- [x] 检查 `README-en.md` 中的本地 HTML 链接目标
- [x] 运行 `git diff --check`，无空白错误

## 检查清单

- [x] 本次更改仅涉及文档
- [x] 已更新相关文档
- [x] 更改不会引入新的警告
- [x] PR 标题清晰描述了更改内容
