### PR TITLE
fix: preserve auto-matched subtitle video IDs

### DIFF
--- a/app/services/jianying_task.py
+++ b/app/services/jianying_task.py
@@ -294,6 +294,7 @@ def _find_original_subtitle_paths_for_videos(video_paths: list[str]) -> list[str
     for video_path in video_paths:
         candidates = _video_stem_candidates(video_path)
         if not candidates:
+            resolved_paths.append("")
             continue
 
         matches = []
@@ -305,6 +306,7 @@ def _find_original_subtitle_paths_for_videos(video_paths: list[str]) -> list[str
                     break
 
         if not matches:
+            resolved_paths.append("")
             continue
 
         matches.sort(key=lambda item: path.getmtime(item), reverse=True)
@@ -312,10 +314,13 @@ def _find_original_subtitle_paths_for_videos(video_paths: list[str]) -> list[str
         if selected_path not in seen:
             resolved_paths.append(selected_path)
             seen.add(selected_path)
+        else:
+            resolved_paths.append("")
 
-    if resolved_paths:
+    if any(resolved_paths):
         logger.info(f"剪映导出未从参数获取原片字幕，已按视频文件名自动匹配: {resolved_paths}")
-    return resolved_paths
+        return resolved_paths
+    return []
 
 
 def _create_jianying_subtitle_file(

--- a/app/services/script_subtitle.py
+++ b/app/services/script_subtitle.py
@@ -147,6 +147,29 @@ def _normalize_paths(paths) -> List[str]:
     return normalized_paths
 
 
+def _normalize_path_slots(paths) -> List[str]:
+    """Keep auto-discovery's empty video slots while normalizing paths."""
+    if isinstance(paths, str):
+        paths = [paths]
+    if not paths:
+        return []
+
+    normalized_paths = []
+    seen = set()
+    for item in paths:
+        if not isinstance(item, str):
+            continue
+        item = item.strip()
+        if not item:
+            normalized_paths.append("")
+            continue
+        if item in seen:
+            continue
+        normalized_paths.append(item)
+        seen.add(item)
+    return normalized_paths
+
+
 def _resolve_script_video_id(item: dict, video_origin_paths: Sequence[str]) -> int:
     video_id = _coerce_positive_int(item.get("video_id") or item.get("video_index"))
     if video_id is not None:
@@ -175,11 +198,13 @@ def _build_combined_original_subtitle_content(
     original_subtitle_paths,
     video_origin_paths=None,
 ) -> str:
-    subtitle_paths = _normalize_paths(original_subtitle_paths)
+    subtitle_paths = _normalize_path_slots(original_subtitle_paths)
     video_paths = _normalize_paths(video_origin_paths)
     sections = []
 
     for index, subtitle_path in enumerate(subtitle_paths, start=1):
+        if not subtitle_path:
+            continue
         if not os.path.exists(subtitle_path):
             logger.warning(f"原片字幕文件不存在，跳过: {subtitle_path}")
             continue

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -148,6 +148,7 @@ def _find_original_subtitle_paths_for_videos(video_paths: list[str]) -> list[str
     for video_path in video_paths:
         candidates = _video_stem_candidates(video_path)
         if not candidates:
+            resolved_paths.append("")
             continue
 
         matches = []
@@ -159,6 +160,7 @@ def _find_original_subtitle_paths_for_videos(video_paths: list[str]) -> list[str
                     break
 
         if not matches:
+            resolved_paths.append("")
             continue
 
         matches.sort(key=lambda item: path.getmtime(item), reverse=True)
@@ -166,10 +168,13 @@ def _find_original_subtitle_paths_for_videos(video_paths: list[str]) -> list[str
         if selected_path not in seen:
             resolved_paths.append(selected_path)
             seen.add(selected_path)
+        else:
+            resolved_paths.append("")
 
-    if resolved_paths:
+    if any(resolved_paths):
         logger.info(f"未从参数获取原片字幕，已按视频文件名自动匹配: {resolved_paths}")
-    return resolved_paths
+        return resolved_paths
+    return []
 
 
 def _create_programmatic_subtitle_file(

--- a/app/services/test_jianying_task_unittest.py
+++ b/app/services/test_jianying_task_unittest.py
@@ -322,6 +322,26 @@ class JianyingTaskTests(unittest.TestCase):
 
             self.assertEqual([str(newer_subtitle)], subtitle_paths)
 
+    def test_auto_matched_subtitle_keeps_empty_slot_for_an_earlier_video(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            first_video = temp_path / "first.mp4"
+            second_video = temp_path / "second_20260829010203.mp4"
+            second_subtitle = temp_path / "second_fun_asr_20260829010204.srt"
+            second_subtitle.write_text("second", encoding="utf-8")
+            params = VideoClipParams(
+                video_origin_paths=[str(first_video), str(second_video)],
+            )
+
+            with patch.object(
+                jianying_task.utils,
+                "subtitle_dir",
+                return_value=str(temp_path),
+            ):
+                subtitle_paths = jianying_task._get_original_subtitle_paths(params)
+
+        self.assertEqual(["", str(second_subtitle)], subtitle_paths)
+
     def test_create_jianying_subtitle_file_includes_original_audio_subtitles(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)

--- a/app/services/test_script_subtitle_unittest.py
+++ b/app/services/test_script_subtitle_unittest.py
@@ -187,6 +187,22 @@ class ScriptSubtitleTests(unittest.TestCase):
         self.assertIn("第二个视频的字幕应该出现", content)
         self.assertNotIn("第一个视频的字幕不应该出现", content)
 
+    def test_combined_original_subtitles_keep_explicit_positional_mapping(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            subtitle_file = Path(temp_dir) / "second.srt"
+            subtitle_file.write_text(
+                "1\n00:00:01,000 --> 00:00:03,000\n显式字幕。\n",
+                encoding="utf-8",
+            )
+
+            content = script_subtitle._build_combined_original_subtitle_content(
+                [str(subtitle_file)],
+                ["first.mp4", "second.mp4"],
+            )
+
+        self.assertIn("# 视频 1: first.mp4", content)
+        self.assertNotIn("# 视频 2: second.mp4", content)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/app/services/test_task_subtitle_resolution_unittest.py
+++ b/app/services/test_task_subtitle_resolution_unittest.py
@@ -4,7 +4,7 @@ import unittest
 from pathlib import Path
 
 from app.models.schema import VideoClipParams
-from app.services import task
+from app.services import script_subtitle, task
 
 
 class TaskSubtitleResolutionTests(unittest.TestCase):
@@ -40,6 +40,53 @@ class TaskSubtitleResolutionTests(unittest.TestCase):
         )
 
         self.assertEqual(["/tmp/provided.srt"], task._get_original_subtitle_paths(params))
+
+    def test_auto_matched_subtitle_keeps_its_video_id_when_earlier_video_has_none(self):
+        original_subtitle_dir = task.utils.subtitle_dir
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            first_video = temp_path / "first.mp4"
+            second_video = temp_path / "second_20260829010203.mp4"
+            second_subtitle = temp_path / "second_fun_asr_20260829010204.srt"
+            output_file = temp_path / "script_subtitles.srt"
+            second_subtitle.write_text(
+                "1\n00:00:01,000 --> 00:00:03,000\n第二个视频的原声字幕。\n",
+                encoding="utf-8",
+            )
+
+            task.utils.subtitle_dir = lambda: str(temp_path)
+            params = VideoClipParams(
+                video_origin_paths=[str(first_video), str(second_video)],
+            )
+
+            try:
+                subtitle_paths = task._get_original_subtitle_paths(params)
+            finally:
+                task.utils.subtitle_dir = original_subtitle_dir
+
+            result = script_subtitle.create_script_subtitle_file(
+                task_id="partial-multi-video-subtitles",
+                list_script=[
+                    {
+                        "_id": 1,
+                        "video_id": 2,
+                        "video_name": second_video.name,
+                        "OST": 1,
+                        "sourceTimeRange": "00:00:01,000-00:00:03,000",
+                        "editedTimeRange": "00:00:00-00:00:02",
+                        "duration": 2,
+                    }
+                ],
+                output_file=str(output_file),
+                original_subtitle_paths=subtitle_paths,
+                video_origin_paths=[str(first_video), str(second_video)],
+            )
+            self.assertEqual(str(output_file), result)
+            content = output_file.read_text(encoding="utf-8")
+
+        self.assertIn("第二个视频的原声字幕", content)
+        self.assertEqual(["", str(second_subtitle)], subtitle_paths)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## PR 类型

- [ ] 破坏性变更 (breaking)
- [ ] 安全修复 (security)
- [ ] 新功能 (feature)
- [x] Bug修复 (bug)
- [ ] 代码重构 (refactor)
- [ ] 依赖升级 (upgrade)
- [ ] 文档更新 (docs)
- [ ] 翻译相关 (lang-all)
- [ ] 内部改进 (internal)

## 描述

多视频任务自动查找原片字幕时，如果较早的视频没有匹配的 SRT、而较后的视频有，返回的字幕路径列表会被压缩。字幕构建器随后把列表位置当作原视频编号，导致较后视频的原声片段找不到字幕，最终可能不生成任何字幕文件。

本修复让标准任务与剪映导出在自动查找时为未匹配的视频保留空槽，并让字幕构建器保留这些槽位。显式传入字幕路径时仍沿用原有的按位置绑定语义。

## 相关 Issue

无。该边界缺陷通过多视频原片字幕流程的本地回归复现发现。

## 更改内容

- 在标准任务与剪映导出的字幕自动查找结果中保留视频位置。
- 构建合并字幕内容时跳过空槽，但不压缩后续视频编号。
- 增加端到端回归、剪映路径覆盖及显式路径兼容性测试。

## 测试

- [x] 单元测试
- [ ] 集成测试
- [ ] 手动测试

验证命令：

- `uv run python -m unittest app.services.test_task_subtitle_resolution_unittest app.services.test_script_subtitle_unittest app.services.test_jianying_task_unittest -v`（28 项通过）
- `uv run python -m unittest discover -v`（共运行 138 项：137 项通过，1 项跳过）
- `uv run python -m compileall app webui tests && uv run python -m py_compile app/services/task.py app/services/jianying_task.py app/services/script_subtitle.py app/services/test_task_subtitle_resolution_unittest.py app/services/test_script_subtitle_unittest.py app/services/test_jianying_task_unittest.py && git diff --check`

## 截图（如果适用）

不适用，本次更改不涉及 UI。

## 检查清单

- [x] 我的代码遵循项目的代码风格
- [x] 我已经添加了必要的测试
- [ ] 我已经更新了相关文档（无需文档变更）
- [x] 我的更改不会引入新的警告
- [x] PR 标题清晰描述了更改内容

## 补充说明

- 同一回归命令在未修改的 `3950ba5662617932f42778159dbcb1a2219e1c79` 上退出码为 `1`，表现为程序化字幕输出为空。
- 应用修复后，同一命令退出码为 `0`，第二个视频的原声字幕被正确生成。
- 变更范围：6 个文件，新增 124 行，删除 6 行。
